### PR TITLE
Add .Net 4.6.1 to targeting frameworks

### DIFF
--- a/LinqToQuerystring.Core/LinqToQuerystring.Core.csproj
+++ b/LinqToQuerystring.Core/LinqToQuerystring.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hello:

I did small changes in the project file to make LinqToQuerystring support .Net Framework 4.6.1.

