### PR TITLE
Make the Unit Test Actually Works

### DIFF
--- a/LinqToQueryString.Tests/LinqToQueryString.Tests.csproj
+++ b/LinqToQueryString.Tests/LinqToQueryString.Tests.csproj
@@ -3,12 +3,16 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <ApplicationIcon />
+
+    <OutputType>Library</OutputType>
+
+    <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/LinqToQueryString.UnitTests/LinqToQueryString.UnitTests.csproj
+++ b/LinqToQueryString.UnitTests/LinqToQueryString.UnitTests.csproj
@@ -4,14 +4,19 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <ApplicationIcon />
+
+    <OutputType>Library</OutputType>
+
+    <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.6.1" />
     <PackageReference Include="Machine.Specifications.Should" Version="0.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="Machine.Specifications" Version="0.12.0" />
   </ItemGroup>

--- a/LinqToQueryString.sln
+++ b/LinqToQueryString.sln
@@ -1,13 +1,12 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinqToQuerystring.Core", "LinqToQuerystring.Core\LinqToQuerystring.Core.csproj", "{1C65FB40-C443-447A-9C4E-152434EE5356}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinqToQuerystring.Core", "LinqToQuerystring.Core\LinqToQuerystring.Core.csproj", "{1C65FB40-C443-447A-9C4E-152434EE5356}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinqToQueryString.UnitTests", "LinqToQueryString.UnitTests\LinqToQueryString.UnitTests.csproj", "{E0E9E5E9-23FE-48A7-B6FB-63A35012BEBC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinqToQueryString.UnitTests", "LinqToQueryString.UnitTests\LinqToQueryString.UnitTests.csproj", "{E0E9E5E9-23FE-48A7-B6FB-63A35012BEBC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinqToQueryString.Tests", "LinqToQueryString.Tests\LinqToQueryString.Tests.csproj", "{434403F2-B149-4C56-84A1-EE9BB0D1F8E9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinqToQueryString.Tests", "LinqToQueryString.Tests\LinqToQueryString.Tests.csproj", "{434403F2-B149-4C56-84A1-EE9BB0D1F8E9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,22 +17,19 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x64.ActiveCfg = Debug|x64
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x64.Build.0 = Debug|x64
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x86.ActiveCfg = Debug|x86
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x86.Build.0 = Debug|x86
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x64.Build.0 = Debug|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x86.Build.0 = Debug|Any CPU
 		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x64.ActiveCfg = Release|x64
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x64.Build.0 = Release|x64
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x86.ActiveCfg = Release|x86
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x86.Build.0 = Release|x86
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x64.ActiveCfg = Release|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x64.Build.0 = Release|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x86.ActiveCfg = Release|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x86.Build.0 = Release|Any CPU
 		{E0E9E5E9-23FE-48A7-B6FB-63A35012BEBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E0E9E5E9-23FE-48A7-B6FB-63A35012BEBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0E9E5E9-23FE-48A7-B6FB-63A35012BEBC}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -58,5 +54,11 @@ Global
 		{434403F2-B149-4C56-84A1-EE9BB0D1F8E9}.Release|x64.Build.0 = Release|Any CPU
 		{434403F2-B149-4C56-84A1-EE9BB0D1F8E9}.Release|x86.ActiveCfg = Release|Any CPU
 		{434403F2-B149-4C56-84A1-EE9BB0D1F8E9}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D9E1C1AE-B77E-4BE7-A0D8-7E0F18BD688C}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Hello:

I realized the unit test in LinqToQuerystring is using Machine.Specifications, not xUnit. To make the unit test works, I added dependencies and removed the xUnit.

Now you can just type `dotnet test` to see all 824 of them pass.