### PR TITLE
Rename Configuration to Context and no longer static

### DIFF
--- a/LinqToQueryString.sln
+++ b/LinqToQueryString.sln
@@ -1,13 +1,12 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinqToQuerystring.Core", "LinqToQuerystring.Core\LinqToQuerystring.Core.csproj", "{1C65FB40-C443-447A-9C4E-152434EE5356}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinqToQuerystring.Core", "LinqToQuerystring.Core\LinqToQuerystring.Core.csproj", "{1C65FB40-C443-447A-9C4E-152434EE5356}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinqToQueryString.UnitTests", "LinqToQueryString.UnitTests\LinqToQueryString.UnitTests.csproj", "{E0E9E5E9-23FE-48A7-B6FB-63A35012BEBC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinqToQueryString.UnitTests", "LinqToQueryString.UnitTests\LinqToQueryString.UnitTests.csproj", "{E0E9E5E9-23FE-48A7-B6FB-63A35012BEBC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinqToQueryString.Tests", "LinqToQueryString.Tests\LinqToQueryString.Tests.csproj", "{434403F2-B149-4C56-84A1-EE9BB0D1F8E9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinqToQueryString.Tests", "LinqToQueryString.Tests\LinqToQueryString.Tests.csproj", "{434403F2-B149-4C56-84A1-EE9BB0D1F8E9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,22 +17,19 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x64.ActiveCfg = Debug|x64
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x64.Build.0 = Debug|x64
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x86.ActiveCfg = Debug|x86
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x86.Build.0 = Debug|x86
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x64.Build.0 = Debug|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Debug|x86.Build.0 = Debug|Any CPU
 		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x64.ActiveCfg = Release|x64
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x64.Build.0 = Release|x64
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x86.ActiveCfg = Release|x86
-		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x86.Build.0 = Release|x86
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x64.ActiveCfg = Release|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x64.Build.0 = Release|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x86.ActiveCfg = Release|Any CPU
+		{1C65FB40-C443-447A-9C4E-152434EE5356}.Release|x86.Build.0 = Release|Any CPU
 		{E0E9E5E9-23FE-48A7-B6FB-63A35012BEBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E0E9E5E9-23FE-48A7-B6FB-63A35012BEBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0E9E5E9-23FE-48A7-B6FB-63A35012BEBC}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -58,5 +54,11 @@ Global
 		{434403F2-B149-4C56-84A1-EE9BB0D1F8E9}.Release|x64.Build.0 = Release|Any CPU
 		{434403F2-B149-4C56-84A1-EE9BB0D1F8E9}.Release|x86.ActiveCfg = Release|Any CPU
 		{434403F2-B149-4C56-84A1-EE9BB0D1F8E9}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8B112D1A-91D4-4EA8-923A-26AD17053D23}
 	EndGlobalSection
 EndGlobal

--- a/LinqToQuerystring.Core/Context.cs
+++ b/LinqToQuerystring.Core/Context.cs
@@ -5,37 +5,42 @@
 
     using LinqToQuerystring.Core.Utils;
 
-    public static class Configuration
+    public class Context
     {
-        public static Func<Type, Type> DefaultTypeMap = (type) => type;
+        private static readonly Lazy<Context> s_context = new Lazy<Context>(() => new Context(), true);
 
-        public static Func<Type, Type, Type> DefaultTypeConversionMap = (from, to) => to;
+        public Func<Type, Type> DefaultTypeMap = (type) => type;
+
+        public Func<Type, Type, Type> DefaultTypeConversionMap = (from, to) => to;
 
         /// <summary>
         /// Exstensibility point for specifying an alternate type mapping when casting to IEnumerable
         /// </summary>
-        public static Func<Type, Type> EnumerableTypeMap { get; set; }
+        public Func<Type, Type> EnumerableTypeMap { get; set; }
 
         /// <summary>
         /// Exstensibility point for specifying an alternate type mapping when casting values
         /// </summary>
-        public static Func<Type, Type, Type> TypeConversionMap { get; set; }
+        public Func<Type, Type, Type> TypeConversionMap { get; set; }
 
         /// <summary>
         /// Allows the specification of custom tree nodes for particular situations, i.e Entity Framework include
         /// </summary>
-        public static Dictionary<string, CustomNodeMappings> CustomNodes { get; set; }
+        public Dictionary<string, CustomNodeMappings> CustomNodes { get; set; }
 
-        public static void Reset()
+        public void Reset()
         {
             EnumerableTypeMap = DefaultTypeMap;
             TypeConversionMap = DefaultTypeConversionMap;
             CustomNodes = new Dictionary<string, CustomNodeMappings>();
         }
 
-        static Configuration()
+        public Context()
         {
             Reset();
         }
+
+
+        public static Context GlobalContext => s_context.Value;
     }
 }

--- a/LinqToQuerystring.Core/TreeNodes/Aggregates/AllNode.cs
+++ b/LinqToQuerystring.Core/TreeNodes/Aggregates/AllNode.cs
@@ -31,7 +31,7 @@
             else
             {
                 //We will sometimes need to cater for special cases here, such as Enumerating BsonValues
-                underlyingType = Configuration.EnumerableTypeMap(underlyingType);
+                underlyingType = Context.EnumerableTypeMap(underlyingType);
                 var enumerable = typeof(IEnumerable<>).MakeGenericType(underlyingType);
                 property = Expression.Convert(property, enumerable);
             }

--- a/LinqToQuerystring.Core/TreeNodes/Aggregates/AnyNode.cs
+++ b/LinqToQuerystring.Core/TreeNodes/Aggregates/AnyNode.cs
@@ -31,7 +31,7 @@
             else
             {
                 //We will sometimes need to cater for special cases here, such as Enumerating BsonValues
-                underlyingType = Configuration.EnumerableTypeMap(underlyingType);
+                underlyingType = Context.EnumerableTypeMap(underlyingType);
                 var enumerable = typeof(IEnumerable<>).MakeGenericType(underlyingType);
                 property = Expression.Convert(property, enumerable);
             }

--- a/LinqToQuerystring.Core/TreeNodes/Aggregates/CountNode.cs
+++ b/LinqToQuerystring.Core/TreeNodes/Aggregates/CountNode.cs
@@ -29,7 +29,7 @@
             else
             {
                 //We will sometimes need to cater for special cases here, such as Enumerating BsonValues
-                underlyingType = Configuration.EnumerableTypeMap(underlyingType);
+                underlyingType = Context.EnumerableTypeMap(underlyingType);
                 var enumerable = typeof(IEnumerable<>).MakeGenericType(underlyingType);
                 property = Expression.Convert(property, enumerable);
             }

--- a/LinqToQuerystring.Core/TreeNodes/Base/TreeNode.cs
+++ b/LinqToQuerystring.Core/TreeNodes/Base/TreeNode.cs
@@ -16,6 +16,8 @@
 
         protected internal readonly TreeNodeFactory factory;
 
+        protected internal Context Context => this.factory.Context;
+
         protected TreeNode(Type inputType, IToken payload, TreeNodeFactory treeNodeFactory)
             : base(payload)
         {
@@ -60,7 +62,7 @@
         public abstract Expression BuildLinqExpression(
             IQueryable query, Expression expression, Expression item = null);
 
-        public virtual Expression BuildLinqExpressionWithComparison( IQueryable query, Expression expression, Expression item = null, Expression compareExpression = null)
+        public virtual Expression BuildLinqExpressionWithComparison(IQueryable query, Expression expression, Expression item = null, Expression compareExpression = null)
         {
             return BuildLinqExpression(query, expression, item);
         }
@@ -70,7 +72,7 @@
             return 0;
         }
 
-        protected static void NormalizeTypes(ref Expression leftSide, ref Expression rightSide)
+        protected void NormalizeTypes(ref Expression leftSide, ref Expression rightSide)
         {
             var rightSideIsConstant = rightSide is ConstantExpression;
             var leftSideIsConstant = leftSide is ConstantExpression;
@@ -107,9 +109,9 @@
             }
         }
 
-        private static Expression MapAndCast(Expression from, Expression to)
+        private Expression MapAndCast(Expression from, Expression to)
         {
-            var mapped = Configuration.TypeConversionMap(from.Type, to.Type);
+            var mapped = Context.TypeConversionMap(from.Type, to.Type);
             if (mapped != from.Type)
             {
                 from = CastIfNeeded(from, mapped);
@@ -118,12 +120,12 @@
             return CastIfNeeded(from, to.Type);
         }
 
-        protected static Expression CastIfNeeded(Expression expression, Type type)
+        protected Expression CastIfNeeded(Expression expression, Type type)
         {
             var converted = expression;
             if (!type.IsAssignableFrom(expression.Type))
             {
-                var convertToType = Configuration.TypeConversionMap(expression.Type, type);
+                var convertToType = Context.TypeConversionMap(expression.Type, type);
                 if (convertToType.IsEnum && expression.Type == typeof(string))
                 {
                 }

--- a/LinqToQuerystring.Core/TreeNodes/TreeNodeFactory.cs
+++ b/LinqToQuerystring.Core/TreeNodes/TreeNodeFactory.cs
@@ -15,8 +15,11 @@
 
         private readonly bool forceDynamicProperties;
 
-        public TreeNodeFactory(Type inputType, bool forceDynamicProperties)
+        public Context Context { get; }
+
+        public TreeNodeFactory(Type inputType, Context context, bool forceDynamicProperties)
         {
+            this.Context = context;
             this.inputType = inputType;
             this.forceDynamicProperties = forceDynamicProperties;
         }


### PR DESCRIPTION
Hello:

I've renamed the `Configuration` class to `Context` and made it not a static class anymore that means you can use multiple configurations with query parsers in a single application or library.